### PR TITLE
simple hack to fix tables documentation on safari

### DIFF
--- a/css/seaff.css
+++ b/css/seaff.css
@@ -557,7 +557,7 @@ hr {
   display: table-cell;
 }
 .section-filter div div.filter-freecell {
-  width: 100%;
+  width: 99%;
 }
 
 .section-filter input {


### PR DESCRIPTION
sample table was using entire row and they could not see table helper text.

I was able to reproduce on Safari 8.0.3
![screenshot 2015-01-27 00 55 52](https://cloud.githubusercontent.com/assets/171371/5912725/4a4dac70-a5bf-11e4-8baf-b8af9b88db9b.png)
