### PR TITLE
Align font-family and font styles with Shopify's newer styling

### DIFF
--- a/css/seaff.css
+++ b/css/seaff.css
@@ -16,13 +16,23 @@
 * GENERAL ELEMENTS
 *******************************************/
 
+html {
+    -webkit-text-size-adjust: 100%;
+    -ms-text-size-adjust: 100%;
+    text-size-adjust: 100%;
+    text-rendering: optimizeLegibility;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+}
+
 * {
-    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
-    font-size: 13px;
+    font-family: -apple-system, BlinkMacSystemFont, 'San Francisco', Roboto, 'Segoe UI', 'Helvetica Neue', sans-serif;
+    font-size: 15px;
+    font-weight: 400;
 }
 
 body {
-    line-height: 18px;
+    line-height: 1.428;
     color: #31373d;
     background: #ebeef0;
     text-align: left;
@@ -104,8 +114,8 @@ form {
 a {
     color: #479ccf;
     text-decoration: none;
-    line-height: 18px;
-    font-size: 13px;
+    line-height: 1.428;
+    font-size: 15px;
     font-weight: none;
     position: relative;
 }
@@ -423,7 +433,7 @@ hr {
     font-size: 18px;
     margin-bottom: 10px;
     margin-bottom: 0px;
-    font-weight: 400;
+    font-weight: 500;
 }
 
 .section-summary p {
@@ -940,7 +950,7 @@ label {
     color: #000;
     display: block;
     margin-bottom: 5px;
-    font-weight: bold;
+    font-weight: 400;
 }
 
 label.label-normal {

--- a/full-width-table.html
+++ b/full-width-table.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+  <link href='https://fonts.googleapis.com/css?family=Roboto:400,500,700' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" type="text/css" href="./css/seaff.css">
   <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.6.4/jquery.min.js"></script>
   <script type="text/javascript" src="./js/snippets-generator.js"></script>

--- a/index.html
+++ b/index.html
@@ -42,9 +42,10 @@
     <meta content="authenticity_token" name="csrf-param">
     <meta content="MKzaEXT0OX5JIIcKEj7BNiAX45uQxciYd5UCOMJ1lDE=" name="csrf-token">
 
+    <link href='https://fonts.googleapis.com/css?family=Roboto:400,500,700' rel='stylesheet' type='text/css'>
     <link data-turbolinks-track="true" href="https://cdn.shopify.com/s/assets/admin/style-a30b16af39a8144195d489e89d162ac6.css" media="all" rel="stylesheet">
     <link data-turbolinks-track="true" href="https://cdn.shopify.com/s/assets/admin/print-7e95040da21512a810c214750b093ec9.css" media="print" rel="stylesheet">
-    
+
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
     <link data-turbolinks-track="true" href="css/seaff-dropdown.css" rel="stylesheet">
     <script type="text/javascript" src="js/jquery-dropdown.js"></script>
@@ -279,11 +280,11 @@
                                 <div class="header-right">
                                     <div class="js-pagination"></div>
                                     <div class="js-buttons">
-                                        
+
                                         <span>
                                             <a id="btn-docs" href="#" class="btn" style="display:none;">SEAFF DOCS</a>
                                         </span>
-                                        
+
                                         <span>
                                             <a href="#" data-jq-dropdown="#jq-dropdown-1" class="btn">
                                                 Examples <i class="ico ico-16 ico-disclosure"></i></a>
@@ -301,11 +302,11 @@
                     </div>
 
                     <iframe id="if-docs" class="app-iframe app-iframe--admin" frameborder="0" name="app-iframe" src="docs.html" style="display: block; height: calc(100% + 67px);"></iframe>
-                    
+
                     <iframe id="if-orders" class="app-iframe app-iframe--admin" frameborder="0" name="app-iframe" src="examples/orders.html" style="visibility:hidden; display:none; height: calc(100% + 67px);"></iframe>
-                    
+
                     <iframe id="if-products" class="app-iframe app-iframe--admin" frameborder="0" name="app-iframe" src="examples/products.html" style="visibility:hidden; display:none; height: calc(100% + 67px);"></iframe>
-                    
+
                     <iframe id="if-customers" class="app-iframe app-iframe--admin" frameborder="0" name="app-iframe" src="examples/customers.html" style="visibility:hidden; display:none; height: calc(100% + 67px);"></iframe>
 
                     <iframe id="if-add-customer" class="app-iframe app-iframe--admin" frameborder="0" name="app-iframe" src="examples/add-customer.html" style="visibility:hidden; display:none; height: calc(100% + 67px);"></iframe>
@@ -315,7 +316,7 @@
                     <iframe id="if-ws-customers" class="app-iframe app-iframe--admin" frameborder="0" name="app-iframe" src="examples/wholesaler-customers-view.html" style="visibility:hidden; display:none; height: calc(100% + 67px);"></iframe>
 
                     <iframe id="if-ws-products" class="app-iframe app-iframe--admin" frameborder="0" name="app-iframe" src="examples/wholesaler-products-view.html" style="visibility:hidden; display:none; height: calc(100% + 67px);"></iframe>
-                    
+
                 </div>
 
                 <div class="hide" define="{resourcePicker: new Shopify.SingleSelectResourcePicker(this, &#39;resource[id]&#39;)}">
@@ -331,7 +332,7 @@
 <div id="modal_backdrop" refresh="modal" class="modal-bg"></div>
 <div class="aviary-modal-bg"><div class="aviary-modal"></div></div>
 <!-- Only pixels that need to see the url all other should go inside the iframe -->
-    
+
     <div id="jq-dropdown-1" class="jq-dropdown jq-dropdown-tip">
         <ul class="jq-dropdown-menu">
             <li><a id="jqd-orders" href="#">Orders list</a></li>
@@ -343,38 +344,38 @@
             <li><a id="jqd-ws-products" href="#">WS products view</a></li>
         </ul>
     </div>
-    
-    
+
+
     <script type="text/javascript">
-        
+
         function hideIframe(iframe) {
             $(iframe).css('display', 'none').css('visibility', 'hidden');
         }
-        
+
         function showIframe(iframe) {
             $(iframe).css('display', 'block').css('visibility', 'visible');
         }
-        
+
         function hideDocsBtn() {
             $('#btn-docs').css('display', 'none');
         }
-        
+
         function showDocsBtn() {
             $('#btn-docs').css('display', 'inline-block');
         }
-        
+
         $('#jqd-orders').on('click', function() {
             hideIframe($('iframe'));
             showIframe($('#if-orders'));
-            showDocsBtn();            
+            showDocsBtn();
         });
-        
+
         $('#jqd-products').on('click', function() {
             hideIframe($('iframe'));
             showIframe($('#if-products'));
             showDocsBtn();
         });
-        
+
         $('#jqd-customers').on('click', function() {
             hideIframe($('iframe'));
             showIframe($('#if-customers'));
@@ -404,13 +405,13 @@
             showIframe($('#if-ws-products'));
             showDocsBtn();
         });
-        
+
         $('#btn-docs').on('click', function() {
             hideIframe($('iframe'));
             showIframe($('#if-docs'));
             hideDocsBtn();
         });
-        
+
     </script>
-    
+
 </body></html>


### PR DESCRIPTION
This adds:

- The newer font stack used by Shopify, with fallback to Roboto. So anyone using the latest OSX will get the correct apple fonts (San Fransisco), and everyone else will get Roboto, which is a very close match.

- Added font-smoothing and rendering to optimize legibility (you'll see it looks slightly thinner and more crisp).

- Increased font-size to 15px with line height of 1.428 to better match Shopify. NOTE: This could increase the height of sections that include paragraph text and links.

- Adjusted font-weight of left hand headings and labels to better match Shopify

Comments/questions welcome ❔ 