### PR TITLE
Updates to Tooltips

### DIFF
--- a/css/seaff.css
+++ b/css/seaff.css
@@ -140,6 +140,12 @@ a.warning {
     color: #d83e3e;
 }
 
+.tooltip {
+    position: relative;
+    display: inline-block;
+    border-bottom: 1px dotted black;
+}
+
 .tooltip-container {
     top: -webkit-calc(100% + 8px);
     top: calc(100% + 8px);
@@ -147,6 +153,17 @@ a.warning {
     line-height: 18px;
     position: absolute;
     z-index: 999;
+}
+
+.tooltip .tooltip-container::after {
+    content: " ";
+    position: absolute;
+    bottom: 100%;  /* At the top of the tooltip */
+    left: 0%;
+    margin-left: -5px;
+    border-width: 5px;
+    border-style: solid;
+    border-color: transparent transparent rgba(33, 37, 41, 0.9) transparent;
 }
 
 .tooltip-label {
@@ -163,6 +180,10 @@ a.warning {
     text-shadow: none;
     white-space: nowrap;
     overflow: hidden;
+}
+
+.tooltip:hover .tooltip-container {
+    visibility: visible;
 }
 
 /*

--- a/docs.html
+++ b/docs.html
@@ -689,19 +689,25 @@
         </div>
         <div class="section-row">
             <div class="section-cell">
+                <a name="links-tooltip"></a>
                 <label>Toolitip modifier</label>
                 <p>The tooltip modifier is used to add to a tag the ability to show a tooltip.</p>
-                <a name="links-tooltip"></a>
-                <a href="#top" class="help">
-                    Tooltip
+
+                <a href="#" class="tooltip">
+                    Hover Over Me
               <span class="tooltip-container">
                 <span class="tooltip-label">This order has a high risk of fraud</span>
               </span>
                 </a>
-                <br /><br /><br /><br />
+                <br /><br /><br />
                 <label for="code-3">Code</label>
                 <div class="container to-code">
-                    <a href="#top" class="help">Help Link</a>
+                    <a href="#" class="tooltip">
+                    Hover Over Me
+              <span class="tooltip-container">
+                <span class="tooltip-label">This order has a high risk of fraud</span>
+              </span>
+                </a>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
I have changed tooltips to allow them to open up during a hover on either a A href or label. I believe this was what was originally intended, and the previous code on the page was mixed up with the 'help' link documentation above it.