### PR TITLE
Change width 065/035 Sections with Shopify's newer styling

### DIFF
--- a/css/seaff.css
+++ b/css/seaff.css
@@ -745,18 +745,18 @@ hr {
 }
 
 .section-content-065 {
-    -webkit-flex: 0 0 65%;
-    -ms-flex: 0 0 65%;
-    flex: 0 0 65%;
+    -webkit-flex: 0 0 66.66%;
+    -ms-flex: 0 0 66.66%;
+    flex: 0 0 66.66%;
     padding: 10px;
     -moz-box-sizing: border-box;
     box-sizing: border-box;
 }
 
 .section-content-035 {
-    -webkit-flex: 0 0 35%;
-    -ms-flex: 0 0 35%;
-    flex: 0 0 35%;
+    -webkit-flex: 0 0 33.33%;
+    -ms-flex: 0 0 33.33%;
+    flex: 0 0 33.33%;
     padding: 10px;
     -moz-box-sizing: border-box;
     box-sizing: border-box;


### PR DESCRIPTION
Current section widths in admin section are actually not 65% and 35%, but instead an even 1/3 and 2/3. This change matches the Shopify Admin CSS specifically.